### PR TITLE
[#1] Fix commits were duplicated on update

### DIFF
--- a/care.js
+++ b/care.js
@@ -96,6 +96,7 @@ function doTheCodes() {
   var weekCommits = 0;
 
   var today = spawn('sh ' + __dirname + '/standup-helper.sh', [repos], {shell:true});
+  todayBox.content = '';
   today.stdout.on('data', data => {
     todayCommits = getCommits(`${data}`, todayBox);
     updateCommitsGraph(todayCommits, weekCommits);
@@ -103,6 +104,7 @@ function doTheCodes() {
   });
 
   var week = spawn('sh ' + __dirname + '/standup-helper.sh', ['-d 7', repos], {shell:true});
+  weekBox.content = '';
   week.stdout.on('data', data => {
     weekCommits = getCommits(`${data}`, weekBox);
     updateCommitsGraph(todayCommits, weekCommits);


### PR DESCRIPTION
https://github.com/notwaldorf/tiny-terminal-care/issues/1

Due to the mechanism which was used to update the codes
(appending data to the existing and then calculating the length of the result)
the commits were duplicated on update, as on update we received the same commits
as we had before it and thus the length of the commits array became

    l = l_prev + l_prev + l_new

where 
- `l` is the total number of commits displayed,
- `l_prev` is the number of commits before update
- `l_next` is the number of new commits

Cleaning the content of the commits boxes right before updating it
resolves the issue.

Close #1 